### PR TITLE
PLAT-3854: enable dependabot and auto-merge for patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions on the first of each month
+      interval: "monthly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      # Check for updates to npm packages on the first of each month
+      interval: "monthly"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,15 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: LeafLink/ci-tools/dependabot-auto-merge@main
+        with:
+          automation-pat: ${{ secrets.LEAFLINK_AUTOMATION_PAT }}
+          update-type: patch


### PR DESCRIPTION
[PLAT-3854](https://leaflink.atlassian.net/browse/PLAT-3854)

# Description
Enable Dependabot for this repository, and configure the `dependabot-auto-merge` workflow to auto-merge dependabot patches.